### PR TITLE
Fixed issue where SearchBar query would clear upon orientation change

### DIFF
--- a/app/src/androidTest/java/com/shawcroftstudios/ticketmastertakehome/SearchBarTest.kt
+++ b/app/src/androidTest/java/com/shawcroftstudios/ticketmastertakehome/SearchBarTest.kt
@@ -1,6 +1,7 @@
 package com.shawcroftstudios.ticketmastertakehome
 
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.hasText
@@ -8,11 +9,14 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ActivityScenario
 import com.shawcroftstudios.ticketmastertakehome.ui.composable.SEARCH_BAR_TEXT_FIELD_TAG
 import com.shawcroftstudios.ticketmastertakehome.ui.composable.SEARCH_BAR_TEXT_FIELD_TRAILING_ICON_TAG
 import com.shawcroftstudios.ticketmastertakehome.ui.composable.SearchBar
 import com.shawcroftstudios.ticketmastertakehome.ui.theme.TicketmasterTakeHomeTheme
 import junit.framework.TestCase.assertEquals
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -21,30 +25,36 @@ class SearchBarTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
+    private lateinit var scenario: ActivityScenario<ComponentActivity>
+
+    private val searchBarTextFieldTag: String = SEARCH_BAR_TEXT_FIELD_TAG
+    private val searchBarTrailingIconTag: String = SEARCH_BAR_TEXT_FIELD_TRAILING_ICON_TAG
+
+    private lateinit var placeholderText: String
+
+    @Before
+    fun setup() {
+        scenario = ActivityScenario.launch(ComponentActivity::class.java)
+    }
+
+    @After
+    fun teardown() {
+        scenario.close()
+    }
+
     @Test
-    fun searchBarTest() {
-
-        val searchBarTextFieldTag: String = SEARCH_BAR_TEXT_FIELD_TAG
-        val searchBarTrailingIconTag: String = SEARCH_BAR_TEXT_FIELD_TRAILING_ICON_TAG
-
-        lateinit var placeholderText: String
+    fun searchBarQueryAndTrailingIconTest() {
 
         val testQuery = "test query"
         var latestQuery = ""
 
-        composeTestRule.setContent {
-
-            placeholderText = stringResource(id = R.string.search_for_event)
-
-            TicketmasterTakeHomeTheme {
-                SearchBar { latestQuery = it }
-            }
+        setupSearchBar {
+            latestQuery = it
         }
 
         // search bar trailing icon should not exist until text is entered
         composeTestRule.onNodeWithTag(searchBarTrailingIconTag).assertDoesNotExist()
         composeTestRule.onNodeWithTag(searchBarTextFieldTag).assert(hasText(placeholderText))
-
 
         // search bar trailing icon should exist after text entry, query should be updated
         composeTestRule.onNodeWithTag(searchBarTextFieldTag).performTextInput(testQuery)
@@ -57,5 +67,46 @@ class SearchBarTest {
         composeTestRule.onNodeWithTag(searchBarTextFieldTag).assert(hasText(placeholderText))
         composeTestRule.onNodeWithTag(searchBarTrailingIconTag).assertDoesNotExist()
         assertEquals("", latestQuery)
+    }
+
+    // orientation changes are also considered activity recreation events
+    @Test
+    fun searchBarActivityRecreationTest() {
+
+        val testQuery = "test query"
+        var latestQuery = ""
+
+
+        setupSearchBar {
+            latestQuery = it
+        }
+
+        composeTestRule.onNodeWithTag(searchBarTextFieldTag).performTextInput(testQuery)
+        composeTestRule.onNodeWithTag(searchBarTextFieldTag).assert(hasText(testQuery))
+        assertEquals(testQuery, latestQuery)
+
+        scenario.recreate()
+
+        setupSearchBar {
+            latestQuery = it
+        }
+
+        composeTestRule.onNodeWithTag(searchBarTextFieldTag).assert(hasText(testQuery))
+        assertEquals(testQuery, latestQuery)
+    }
+
+    private fun setupSearchBar(onQueryChange: (String) -> Unit) {
+        scenario.onActivity { activity ->
+            activity.setContent {
+
+                placeholderText = stringResource(id = R.string.search_for_event)
+
+                TicketmasterTakeHomeTheme {
+                    SearchBar {
+                        onQueryChange(it)
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/shawcroftstudios/ticketmastertakehome/ui/composable/SearchBar.kt
+++ b/app/src/main/java/com/shawcroftstudios/ticketmastertakehome/ui/composable/SearchBar.kt
@@ -19,7 +19,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -39,7 +39,7 @@ import com.shawcroftstudios.ticketmastertakehome.R
 @Composable
 fun SearchBar(modifier: Modifier = Modifier, onQueryChange: (String) -> Unit) {
 
-    var query by remember { mutableStateOf("") }
+    var query by rememberSaveable { mutableStateOf("") }
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
 


### PR DESCRIPTION
### Issue
Encountered a bug where the text in the `SearchBar`  composable would clear upon orientation change (ie going from portrait to landscape orientation). Expected behaviour is that the `SearchBar` should survive orientation changes

### Steps to reproduce
- Run the app with either internet enabled on the device or cached event results present on the device
- Search for an existing event by typing an event name into the search bar (eg 'Busted')
- The searched for event should display
- Rotate the device to force an orientation change
- Note that the filtered event list should still display **but** the search bar text has been cleared

### Solution
This was a simple problem to fix- the issue was the fact that the `query` mutable state was wrapped in a `remember` block instead of a `rememberSaveable` block. From the documentation:

> It [`rememberSaveable`] behaves similarly to remember, but the stored value will survive the activity or process recreation using the saved instance state mechanism (for example it happens when the screen is rotated in the Android application).

### Tests added
- Updated `SearchBarTest` UI test to test for a scenario in which the activity is recreated. It now expects the query to survive activity recreation

### Screenshots
####  Portrait 
![image](https://github.com/josephshawcroft/Ticketmaster-Take-Home/assets/8886237/b9d22ab9-76c5-4f72-b30d-026449df22f7)

#### Landscape 
![image](https://github.com/josephshawcroft/Ticketmaster-Take-Home/assets/8886237/32ca5363-3b87-4004-8a14-53cc7223e95e)


